### PR TITLE
CRITICAL FIX: Remove stdout logging that breaks MCP handshake

### DIFF
--- a/dist/handlers/config-handler.js
+++ b/dist/handlers/config-handler.js
@@ -1,9 +1,11 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
+import { fileURLToPath } from 'url';
 import { glob } from 'glob';
 export class ConfigHandler {
     templateDir;
     constructor() {
+        const __dirname = path.dirname(fileURLToPath(import.meta.url));
         this.templateDir = path.join(__dirname, '../templates');
     }
     async getConfig(args) {

--- a/dist/handlers/keybinding-handler.js
+++ b/dist/handlers/keybinding-handler.js
@@ -1,8 +1,10 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
+import { fileURLToPath } from 'url';
 export class KeybindingHandler {
     templateDir;
     constructor() {
+        const __dirname = path.dirname(fileURLToPath(import.meta.url));
         this.templateDir = path.join(__dirname, '../templates');
     }
     async getKeybindings(args) {

--- a/dist/handlers/orchestra-handler.js
+++ b/dist/handlers/orchestra-handler.js
@@ -1,5 +1,6 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
+import { fileURLToPath } from 'url';
 import { exec, spawn } from 'child_process';
 import { promisify } from 'util';
 const execAsync = promisify(exec);
@@ -8,6 +9,7 @@ export class OrchestraHandler {
     orchestraDir;
     templateDir;
     constructor() {
+        const __dirname = path.dirname(fileURLToPath(import.meta.url));
         this.templateDir = path.join(__dirname, '../templates');
         this.scriptsDir = path.join(__dirname, '../scripts');
         this.orchestraDir = path.join(this.templateDir, 'orchestra');

--- a/dist/handlers/plugin-handler.js
+++ b/dist/handlers/plugin-handler.js
@@ -1,5 +1,6 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
+import { fileURLToPath } from 'url';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 const execAsync = promisify(exec);
@@ -7,6 +8,7 @@ export class PluginHandler {
     templateDir;
     lazyLockPath;
     constructor() {
+        const __dirname = path.dirname(fileURLToPath(import.meta.url));
         this.templateDir = path.join(__dirname, '../templates');
         this.lazyLockPath = path.join(this.templateDir, 'lazy-lock.json');
     }

--- a/dist/handlers/session-handler.js
+++ b/dist/handlers/session-handler.js
@@ -2,11 +2,13 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 import { exec } from 'child_process';
 import { promisify } from 'util';
+import { fileURLToPath } from 'url';
 const execAsync = promisify(exec);
 export class SessionHandler {
     sessionDir;
     templateDir;
     constructor() {
+        const __dirname = path.dirname(fileURLToPath(import.meta.url));
         this.templateDir = path.join(__dirname, '../templates');
         this.sessionDir = path.join(this.templateDir, 'sessions');
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -445,7 +445,7 @@ class NvimMCPServer {
     async run() {
         const transport = new StdioServerTransport();
         await this.server.connect(transport);
-        console.error('MCP Server for Neovim started successfully');
+        // Server started
     }
 }
 // Start the server

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lepion/mcp-server-nvim",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lepion/mcp-server-nvim",
-  "version": "1.0.0",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lepion/mcp-server-nvim",
-      "version": "1.0.0",
+      "version": "1.0.6",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@lepion/mcp-server-nvim",
-  "version": "1.0.1",
+  "version": "1.0.6",
   "description": "Model Context Protocol server for Neovim NvChad configuration management, plugin orchestration, and multi-instance synchronization",
-  "type": "module",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "bin": {
     "mcp-server-nvim": "dist/index.js"
   },
@@ -41,7 +41,7 @@
     "url": "https://github.com/kayaozkur/mcp-server-nvim/issues"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.0.3",
+    "@modelcontextprotocol/sdk": "^1.13.0",
     "chokidar": "^3.5.3",
     "execa": "^8.0.0",
     "fs-extra": "^11.0.0",

--- a/src/handlers/config-handler.ts
+++ b/src/handlers/config-handler.ts
@@ -1,11 +1,13 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
+import { fileURLToPath } from 'url';
 import { glob } from 'glob';
 
 export class ConfigHandler {
   private templateDir: string;
 
   constructor() {
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
     this.templateDir = path.join(__dirname, '../templates');
   }
 

--- a/src/handlers/health-handler.ts
+++ b/src/handlers/health-handler.ts
@@ -2,6 +2,7 @@ import which from 'which';
 import { execa } from 'execa';
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import { fileURLToPath } from 'url';
 import * as os from 'os';
 
 interface HealthCheckResult {

--- a/src/handlers/keybinding-handler.ts
+++ b/src/handlers/keybinding-handler.ts
@@ -1,10 +1,12 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
+import { fileURLToPath } from 'url';
 
 export class KeybindingHandler {
   private templateDir: string;
 
   constructor() {
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
     this.templateDir = path.join(__dirname, '../templates');
   }
 

--- a/src/handlers/orchestra-handler.ts
+++ b/src/handlers/orchestra-handler.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
+import { fileURLToPath } from 'url';
 import { exec, spawn } from 'child_process';
 import { promisify } from 'util';
 
@@ -11,6 +12,7 @@ export class OrchestraHandler {
   private templateDir: string;
 
   constructor() {
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
     this.templateDir = path.join(__dirname, '../templates');
     this.scriptsDir = path.join(__dirname, '../scripts');
     this.orchestraDir = path.join(this.templateDir, 'orchestra');

--- a/src/handlers/plugin-handler.ts
+++ b/src/handlers/plugin-handler.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
+import { fileURLToPath } from 'url';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 
@@ -10,6 +11,7 @@ export class PluginHandler {
   private lazyLockPath: string;
 
   constructor() {
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
     this.templateDir = path.join(__dirname, '../templates');
     this.lazyLockPath = path.join(this.templateDir, 'lazy-lock.json');
   }

--- a/src/handlers/session-handler.ts
+++ b/src/handlers/session-handler.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 import { exec } from 'child_process';
 import { promisify } from 'util';
+import { fileURLToPath } from 'url';
 
 const execAsync = promisify(exec);
 
@@ -10,6 +11,7 @@ export class SessionHandler {
   private templateDir: string;
 
   constructor() {
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
     this.templateDir = path.join(__dirname, '../templates');
     this.sessionDir = path.join(this.templateDir, 'sessions');
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -476,7 +476,7 @@ class NvimMCPServer {
     const transport = new StdioServerTransport();
     await this.server.connect(transport);
     
-    console.error('MCP Server for Neovim started successfully');
+    // Server started
   }
 }
 


### PR DESCRIPTION
## Critical Fix
- Fix __dirname ES module issue  
- Remove stdout logging that breaks MCP handshake
- Update MCP SDK to 1.13.0

Published as @lepion/mcp-server-nvim@1.0.6